### PR TITLE
FISH-7757 FISH-8344 Deprecate JSONP-API to 2.1.0

### DIFF
--- a/bundles/dist/pom.xml
+++ b/bundles/dist/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>parsson-bundles</artifactId>
-        <version>1.1.5.payara-p1-SNAPSHOT</version>
+        <version>1.1.5.payara-p1</version>
     </parent>
 
     <artifactId>parsson-dist</artifactId>

--- a/bundles/dist/pom.xml
+++ b/bundles/dist/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>parsson-bundles</artifactId>
-        <version>1.1.5.payara-p1</version>
+        <version>1.1.5.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>parsson-dist</artifactId>

--- a/bundles/jakarta.json/pom.xml
+++ b/bundles/jakarta.json/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>parsson-bundles</artifactId>
-        <version>1.1.5.payara-p1-SNAPSHOT</version>
+        <version>1.1.5.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>org.eclipse.parsson</groupId>
     <artifactId>jakarta.json</artifactId>
-    <version>1.1.5.payara-p1-SNAPSHOT</version>
+    <version>1.1.5.payara-p1</version>
     <name>JSON-P with Parsson Provider</name>
     <description>Default provider for Jakarta JSON Processing</description>
 

--- a/bundles/jakarta.json/pom.xml
+++ b/bundles/jakarta.json/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>parsson-bundles</artifactId>
-        <version>1.1.5.payara-p1</version>
+        <version>1.1.5.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>org.eclipse.parsson</groupId>
     <artifactId>jakarta.json</artifactId>
-    <version>1.1.5.payara-p1</version>
+    <version>1.1.5.payara-p2-SNAPSHOT</version>
     <name>JSON-P with Parsson Provider</name>
     <description>Default provider for Jakarta JSON Processing</description>
 

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>project</artifactId>
-        <version>1.1.5.payara-p1-SNAPSHOT</version>
+        <version>1.1.5.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>project</artifactId>
-        <version>1.1.5.payara-p1</version>
+        <version>1.1.5.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/customprovider-jdk9/pom.xml
+++ b/demos/customprovider-jdk9/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5.payara-p1</version>
+        <version>1.1.5.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/customprovider-jdk9/pom.xml
+++ b/demos/customprovider-jdk9/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5.payara-p1-SNAPSHOT</version>
+        <version>1.1.5.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/facebook/pom.xml
+++ b/demos/facebook/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5.payara-p1</version>
+        <version>1.1.5.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/facebook/pom.xml
+++ b/demos/facebook/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5.payara-p1-SNAPSHOT</version>
+        <version>1.1.5.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/jsonpointer/pom.xml
+++ b/demos/jsonpointer/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5.payara-p1</version>
+        <version>1.1.5.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/jsonpointer/pom.xml
+++ b/demos/jsonpointer/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5.payara-p1-SNAPSHOT</version>
+        <version>1.1.5.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/pom.xml
+++ b/demos/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>project</artifactId>
-        <version>1.1.5.payara-p1</version>
+        <version>1.1.5.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/pom.xml
+++ b/demos/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>project</artifactId>
-        <version>1.1.5.payara-p1-SNAPSHOT</version>
+        <version>1.1.5.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/rest/pom.xml
+++ b/demos/rest/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5.payara-p1</version>
+        <version>1.1.5.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/rest/pom.xml
+++ b/demos/rest/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5.payara-p1-SNAPSHOT</version>
+        <version>1.1.5.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/servlet/pom.xml
+++ b/demos/servlet/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5.payara-p1</version>
+        <version>1.1.5.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/servlet/pom.xml
+++ b/demos/servlet/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5.payara-p1-SNAPSHOT</version>
+        <version>1.1.5.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/twitter/pom.xml
+++ b/demos/twitter/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5.payara-p1</version>
+        <version>1.1.5.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/twitter/pom.xml
+++ b/demos/twitter/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.5.payara-p1-SNAPSHOT</version>
+        <version>1.1.5.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>project</artifactId>
-        <version>1.1.5.payara-p1-SNAPSHOT</version>
+        <version>1.1.5.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>org.eclipse.parsson</groupId>
     <artifactId>parsson</artifactId>
-    <version>1.1.5.payara-p1-SNAPSHOT</version>
+    <version>1.1.5.payara-p1</version>
     <name>Eclipse Parsson</name>
     <description>Jakarta JSON Processing provider</description>
 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>project</artifactId>
-        <version>1.1.5.payara-p1</version>
+        <version>1.1.5.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>org.eclipse.parsson</groupId>
     <artifactId>parsson</artifactId>
-    <version>1.1.5.payara-p1</version>
+    <version>1.1.5.payara-p2-SNAPSHOT</version>
     <name>Eclipse Parsson</name>
     <description>Jakarta JSON Processing provider</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -497,6 +497,57 @@
             <!-- to make sure that release profile deactivates building samples -->
             <id>oss-release</id>
         </profile>
+
+        <profile>
+            <id>patched-project-release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <groupId>org.eclipse.parsson</groupId>
     <artifactId>project</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.5.payara-p1-SNAPSHOT</version>
+    <version>1.1.5.payara-p1</version>
     <name>Eclipse Parsson Project</name>
     <description>Jakarta JSON Processing defines a Java(R) based framework for parsing, generating, transforming, and querying JSON documents.</description>
     <url>https://github.com/eclipse-ee4j/parsson</url>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <groupId>org.eclipse.parsson</groupId>
     <artifactId>project</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.5.payara-p1</version>
+    <version>1.1.5.payara-p2-SNAPSHOT</version>
     <name>Eclipse Parsson Project</name>
     <description>Jakarta JSON Processing defines a Java(R) based framework for parsing, generating, transforming, and querying JSON documents.</description>
     <url>https://github.com/eclipse-ee4j/parsson</url>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <spotbugs.threshold>Low</spotbugs.threshold>
         <spotbugs.version>4.7.3.6</spotbugs.version>
 
-        <jakarta.json-api.version>2.1.3</jakarta.json-api.version>
+        <jakarta.json-api.version>2.1.0</jakarta.json-api.version>
 
         <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
         <jakarta.xml.bind-api.version>4.0.1</jakarta.xml.bind-api.version>

--- a/providers/customprovider/pom.xml
+++ b/providers/customprovider/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>providers</artifactId>
-        <version>1.1.5.payara-p1-SNAPSHOT</version>
+        <version>1.1.5.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/providers/customprovider/pom.xml
+++ b/providers/customprovider/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>providers</artifactId>
-        <version>1.1.5.payara-p1</version>
+        <version>1.1.5.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/providers/defaultprovider/pom.xml
+++ b/providers/defaultprovider/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>providers</artifactId>
-        <version>1.1.5.payara-p1-SNAPSHOT</version>
+        <version>1.1.5.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/providers/defaultprovider/pom.xml
+++ b/providers/defaultprovider/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>providers</artifactId>
-        <version>1.1.5.payara-p1</version>
+        <version>1.1.5.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/providers/pom.xml
+++ b/providers/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>project</artifactId>
-        <version>1.1.5.payara-p1-SNAPSHOT</version>
+        <version>1.1.5.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/providers/pom.xml
+++ b/providers/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>project</artifactId>
-        <version>1.1.5.payara-p1</version>
+        <version>1.1.5.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -23,14 +23,14 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>project</artifactId>
-        <version>1.1.5.payara-p1</version>
+        <version>1.1.5.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>org.eclipse.parsson</groupId>
     <artifactId>parsson-media</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.5.payara-p1</version>
+    <version>1.1.5.payara-p2-SNAPSHOT</version>
     <name>Eclipse Parsson Media for Jakarta RESTful Web Services</name>
     <description>Jakarta RESTful Web Services MessageBodyReader and MessageBodyWriter to support JsonValue API of Jakarta JSON Processing</description>
 

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -23,14 +23,14 @@
     <parent>
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>project</artifactId>
-        <version>1.1.5.payara-p1-SNAPSHOT</version>
+        <version>1.1.5.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>org.eclipse.parsson</groupId>
     <artifactId>parsson-media</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.5.payara-p1-SNAPSHOT</version>
+    <version>1.1.5.payara-p1</version>
     <name>Eclipse Parsson Media for Jakarta RESTful Web Services</name>
     <description>Jakarta RESTful Web Services MessageBodyReader and MessageBodyWriter to support JsonValue API of Jakarta JSON Processing</description>
 


### PR DESCRIPTION
**TEMPORARY WORKAROUND**
Deprecate JSONP-API to 2.1.0 as the upstream changes to the `JsonProvider.provider()` method breaks our TCK runner.

With the reworked mechanism of loading the system property it gets resolved in our TCK runner, and thus fails to load because we're using the OSGi class loader at this point - The `jakarta.json.jar` doesn't have the dummy TCK factory class as an OSGi import or available on its BundleWiring class loader.